### PR TITLE
Add version override

### DIFF
--- a/rpmbuild/SPECS/opencast.spec
+++ b/rpmbuild/SPECS/opencast.spec
@@ -14,6 +14,10 @@
 %define ocdist allinone
 %endif
 
+%if "%{?tarversion}" == ""
+%define tarversion %{version}
+%endif
+
 Name:          opencast-%{ocdist}
 Version:       %{srcversion}
 Release:       1%{?dist}
@@ -22,7 +26,7 @@ Summary:       Open Source Lecture Capture & Video Management Tool
 Group:         Applications/Multimedia
 License:       ECL 2.0
 URL:           https://opencast.org
-Source0:       opencast-dist-%{ocdist}-%{srcversion}.tar.gz
+Source0:       opencast-dist-%{ocdist}-%{tarversion}.tar.gz
 Source1:       jetty.xml
 Source2:       opencast.logrotate
 Source3:       org.apache.aries.transaction.cfg


### PR DESCRIPTION
Adding tarversion variable, which allows for setting things like a version of 10-SNAPSHOT.  If this variable is *not* set then it defaults to existing behaviour, this just makes building point versions (eg: [opencast-admin-10.x-44.843ac98f9.el7.noarch.rpm](http://build.loganite.ca/#/builders/59/builds/44/steps/10/logs/admin) doable.