### PR TITLE
Initial support for el9

### DIFF
--- a/.github/workflows/build-rpms.yml
+++ b/.github/workflows/build-rpms.yml
@@ -12,10 +12,11 @@ jobs:
         osversion:
           - el7
           - el8
+          - el9
     name: build (${{ matrix.osversion }})
     runs-on: ubuntu-20.04
     container:
-      image: docker.io/lkiesow/opencast-rpmbuild:${{ matrix.osversion }}-oc10.2
+      image: docker.io/lkiesow/opencast-rpmbuild:${{ matrix.osversion }}-oc10.3
     steps:
       - uses: actions/checkout@v2
 

--- a/container-files/Dockerfile.el7
+++ b/container-files/Dockerfile.el7
@@ -1,6 +1,7 @@
-FROM docker.io/library/centos:7
+FROM quay.io/centos/centos:7
 
-RUN yum install -y https://pkg.opencast.org/rpms/release/el/7/noarch/opencast-repository-8-0-1.el8.noarch.rpm \
+RUN yum -y update \
+    && yum -y install https://pkg.opencast.org/rpms/release/el/7/noarch/opencast-repository-8-0-1.el8.noarch.rpm \
     && yum -y install epel-release \
 	 && yum -y update \
     && yum -y clean all

--- a/container-files/Dockerfile.el9
+++ b/container-files/Dockerfile.el9
@@ -1,23 +1,24 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
-RUN dnf install -y https://pkg.opencast.org/rpms/release/el/8/noarch/opencast-repository-8-0-1.el8.noarch.rpm \
-    && dnf -y install epel-release \
+RUN dnf -y install https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/e/epel-release-9-2.el9.noarch.rpm \
+    && dnf install -y https://pkg.opencast.org/rpms/release/el/8/oc-10/noarch/opencast-repository-10-1.el8.noarch.rpm \
     && dnf -y clean all
-RUN dnf -y install https://data.lkiesow.io/opencast/maven-3.8.2-1.el8.noarch.rpm
-RUN dnf -y install \
+RUN dnf -y install python3-pip \
+    && pip3 install s3cmd \
+    && dnf -y install \
     dnf-plugins-core \
     rpmdevtools \
     rpmlint \
     sudo \
     bzip2 \
     java-11-devel \
-	 jq \
+    jq \
+    maven \
     sed \
     tar \
     xz \
     gzip \
     git \
-	 s3cmd \
     systemd \
     && dnf -y clean all
 RUN useradd --no-create-home makerpm


### PR DESCRIPTION
This patch adds initial support for an el9 build.
It is now using CentOS Stream 8/9 as a base.